### PR TITLE
RaspberryPiMouseDevice.hがインクルードされておらずコンパイルエラーが出る件について

### DIFF
--- a/include/RaspberryPiMouseRTC/RaspberryPiMouseDevice.h
+++ b/include/RaspberryPiMouseRTC/RaspberryPiMouseDevice.h
@@ -19,7 +19,8 @@
 //https://github.com/rt-net/RaspberryPiMouse
 ///////////////////////////////////////////////////////////////////////
 #include <string>
-#include <time.h>
+//#include <time.h>
+#include <sys/time.h>
 
 namespace RPMD
 {
@@ -88,8 +89,8 @@ namespace RPMD
 			double current_y;
 			double current_w;
 
-			clock_t prev_clock;
-			clock_t current_clock;
+			struct timeval prev_clock;
+			struct timeval current_clock;
 
 			std::string moteren;
 			std::string buzzer;

--- a/include/RaspberryPiMouseRTC/RaspberryPiMouseRTC.h
+++ b/include/RaspberryPiMouseRTC/RaspberryPiMouseRTC.h
@@ -36,6 +36,8 @@ using namespace RTC;
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 
+#include "RaspberryPiMouseDevice.h"
+
 /*!
  * @class RaspberryPiMouseRTC
  * @brief RaspberryPiMouseRTC

--- a/src/RaspberryPiMouseDevice.cpp
+++ b/src/RaspberryPiMouseDevice.cpp
@@ -31,7 +31,7 @@ namespace RPMD
 	RaspberryPiMouseDevice::RaspberryPiMouseDevice()
 		: wheels_distance(0.0), wheel_dir(0.0), step_angle(0.0), max_frequency(), acceleration(), current_frequency(), 
 		target_frequency(), current_x(0.0), current_y(0.0), current_w(0.0), 
-		prev_clock(), current_clock(), moteren("/dev/rtmoteren0"), 
+		prev_clock(), current_clock(), moteren("/dev/rtmotoren0"), 
 		buzzer("/dev/rtbuzzer0"), motor(), led(), push_switch(), 
 		irsensor("/dev/rtlightsensor0")
 	{

--- a/src/RaspberryPiMouseDevice.cpp
+++ b/src/RaspberryPiMouseDevice.cpp
@@ -110,7 +110,7 @@ namespace RPMD
 	double RaspberryPiMouseDevice::getCurrentTangentialVelocity()
 	{
 		return ((current_frequency[RIGHT] - current_frequency[LEFT])
-			/ wheels_distance) / 2.0 * step_angle * (wheel_dir / 2.0);
+			/ (wheels_distance / 2.0)) / 2.0 * step_angle * (wheel_dir / 2.0);
 	}
 
 	void RaspberryPiMouseDevice::setTargetVelocity(double _v_forward, 
@@ -118,12 +118,16 @@ namespace RPMD
 	{
 		int frequency[nSTM];
 		double _v[nSTM];
+		
 		_v[LEFT] = _v_forward - _v_rotation * wheels_distance / 2.0; 
 		_v[RIGHT] = _v_forward + _v_rotation * wheels_distance / 2.0;
+		
+		
 		for(size_t i = 0; i < nSTM; ++i)
 		{
 			
 			frequency[i] = _v[i] / (wheel_dir / 2.0) / step_angle;
+			//std::cout << frequency[i] << "\t" << max_frequency << std::endl;
 			if(frequency[i] > max_frequency)
 			{
 				frequency[i] = max_frequency;
@@ -207,6 +211,8 @@ namespace RPMD
 		//std::cout << ctime << std::endl;
 		if(diff_time <= 0.0){gettimeofday(&prev_clock, NULL); return;}
 		if(diff_time > 0.5){gettimeofday(&prev_clock, NULL); return;}
+
+		//std::cout << current_frequency[LEFT] << std::endl;
 
 		double v_forward = 
 			(current_frequency[LEFT] + current_frequency[RIGHT]) / 2.0 * (wheel_dir / 2.0) * step_angle; 

--- a/src/RaspberryPiMouseRTC.cpp
+++ b/src/RaspberryPiMouseRTC.cpp
@@ -34,7 +34,7 @@ static const char* raspberrypimousertc_spec[] =
 	"conf.default.max_tangential_acceleration", "0.314",
 	"conf.default.distance_of_wheels", "0.095",
 	"conf.default.diameter_of_wheel", "0.048",
-	"conf.default.step_angle", "1.8",
+	"conf.default.step_angle", "0.9",
 	// Widget
 	"conf.__widget__.max_velocity", "text",
 	"conf.__widget__.max_acceleration", "text",
@@ -111,7 +111,7 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onInitialize()
 	bindParameter("max_tangential_acceleration", m_max_tangential_acceleration, "0.314");
 	bindParameter("distance_of_wheels", m_distance_of_wheels, "0.095");
 	bindParameter("diameter_of_wheel", m_diameter_of_wheel, "0.048");
-	bindParameter("step_angle", m_step_angle, "1.8");
+	bindParameter("step_angle", m_step_angle, "0.9");
 	// </rtc-template>
 
 	return RTC::RTC_OK;

--- a/src/RaspberryPiMouseRTC.cpp
+++ b/src/RaspberryPiMouseRTC.cpp
@@ -7,6 +7,9 @@
  * $Id$
  */
 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include "RaspberryPiMouseRTC.h"
 
 // Module specification
@@ -150,6 +153,9 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onActivated(RTC::UniqueId ec_id)
 		m_switch3bit_out.data[i] = false;
 	}
 
+	double step_angle_radian = m_step_angle*M_PI/180;
+	
+
 	m_current_velocity_out.data.vx = 0.0;
 	m_current_velocity_out.data.vy = 0.0;
 	m_current_velocity_out.data.va = 0.0;
@@ -159,12 +165,12 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onActivated(RTC::UniqueId ec_id)
 	m_current_pose_out.data.heading = 0.0;
 
 	rpmd.setBodyParameter(m_distance_of_wheels, m_diameter_of_wheel, 
-			m_step_angle);
+			step_angle_radian);
 
 	rpmd.setMaxFrequency(m_max_velocity / (m_diameter_of_wheel / 2.0)
-			/ m_step_angle);
+			/ step_angle_radian);
 	rpmd.setAcceleration(m_max_acceleration / (m_diameter_of_wheel / 2.0)
-			/ m_step_angle);
+			/ step_angle_radian);
 
 	rpmd.servoON();
 
@@ -185,9 +191,9 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onExecute(RTC::UniqueId ec_id)
 	{
 		m_target_velocity_inIn.read();
 
-		std::cout << "vx: " << m_target_velocity_in.data.vx << std::endl;
-		std::cout << "vy: " << m_target_velocity_in.data.vy << std::endl;
-		std::cout << "va: " << m_target_velocity_in.data.va << std::endl;
+		//std::cout << "vx: " << m_target_velocity_in.data.vx << std::endl;
+		//std::cout << "vy: " << m_target_velocity_in.data.vy << std::endl;
+		//std::cout << "va: " << m_target_velocity_in.data.va << std::endl;
 
 		rpmd.setTargetVelocity(m_target_velocity_in.data.vx, 
 				m_target_velocity_in.data.va);
@@ -208,9 +214,9 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onExecute(RTC::UniqueId ec_id)
 */
 /*
 		rpmd.setVelocity(RPMD::LEFT,
-				vL / (m_diameter_of_wheel / 2.0) / m_step_angle);
+				vL / (m_diameter_of_wheel / 2.0) / step_angle_radian);
 		rpmd.setVelocity(RPMD::RIGHT,
-				vR / (m_diameter_of_wheel / 2.0) / m_step_angle);
+				vR / (m_diameter_of_wheel / 2.0) / step_angle_radian);
 */
 	}
 
@@ -224,20 +230,20 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onExecute(RTC::UniqueId ec_id)
 	if(m_led4bit_inIn.isNew())
 	{
 		m_led4bit_inIn.read();
-		std::cout << "get led command" << std::endl;
+		//std::cout << "get led command" << std::endl;
 
 		for(size_t i = 0; i < static_cast< size_t >(RPMD::nLED); ++i)
 		{
-			std::cout << (m_led4bit_in.data[i] ? "ON " : "OFF ");
+			//std::cout << (m_led4bit_in.data[i] ? "ON " : "OFF ");
 			rpmd.setLED(static_cast< RPMD::LED_e >(i), m_led4bit_in.data[i]);
 		}
-		std::cout << std::endl;
+		//std::cout << std::endl;
 	}
 
 	if(m_buzzer_hz_inIn.isNew())
 	{
 		m_buzzer_hz_inIn.read();
-		std::cout << "get buzzer command" << std::endl;
+		//std::cout << "get buzzer command" << std::endl;
 
 		rpmd.setBUZZER(m_buzzer_hz_in.data);
 	}
@@ -246,9 +252,9 @@ RTC::ReturnCode_t RaspberryPiMouseRTC::onExecute(RTC::UniqueId ec_id)
 
 /*
 	double current_vL = rpmd.getCurrentVelocity(RPMD::LEFT)
-		* m_step_angle * m_diameter_of_wheel / 2.0;
+		* step_angle_radian * m_diameter_of_wheel / 2.0;
 	double current_vR = rpmd.getCurrentVelocity(RPMD::RIGHT)
-		* m_step_angle * m_diameter_of_wheel / 2.0;
+		* step_angle_radian * m_diameter_of_wheel / 2.0;
 	m_current_velocity.data.vx = (current_vL + current_vR) / 2.0;
 	m_current_velocity.data.va = (current_vR - current_vL)
 		* m_distance_of_wheels / 2.0;


### PR DESCRIPTION
RaspberryPiMouseRTCを使いたいと思ってビルドしようとしたのですが、RaspberryPiMouseDevice.hがRaspberryPiMouseRTC.hやRaspberryPiMouseRTC.cppではインクルードされていないらしくエラーが出ました。
ビルドの手順がREADME.mdには書いていなかったのですが、何か特別な手順があるのであれば教えていただけますでしょうか？

補足ですが、インポートで受信したデータを常に標準出力し続けるのはできればやめてほしいです。
デバッグの時だけ出力するとかにした方がいいかもしれないです。

よろしくお願いします。
